### PR TITLE
Fix FFT inputs (signed vs unsigned)

### DIFF
--- a/btstack_audio_pico.cpp
+++ b/btstack_audio_pico.cpp
@@ -145,8 +145,7 @@ static void btstack_audio_pico_sink_fill_buffers(void){
         }
         fft.update();
         for (auto i = 0u; i < galactic.WIDTH; i++) {
-            uint16_t sample = std::min((int16_t)2800, (int16_t)fft.get_scaled(i + 2, 1));
-            sample = std::max((uint16_t)0, sample);
+            uint16_t sample = std::min((int16_t)2800, (int16_t)fft.get_scaled_fix15(i + 2, float_to_fix15(3.5)));
             for (auto y = 0; y < 11; y++) {
                 uint8_t r = std::min((uint16_t)255, sample);
                 uint8_t b = r;

--- a/fixed_fft.cpp
+++ b/fixed_fft.cpp
@@ -24,6 +24,10 @@ int FIX_FFT::get_scaled(unsigned int i, unsigned int scale) {
     return fix15_to_int(multiply_fix15(fr[i], int_to_fix15(scale)));
 }
 
+int FIX_FFT::get_scaled_fix15(unsigned int i, fix15 scale) {
+    return fix15_to_int(multiply_fix15(fr[i], scale));
+}
+
 void FIX_FFT::init() {
 
     // Populate Filter and Sine tables
@@ -71,6 +75,13 @@ float FIX_FFT::max_frequency() {
     return max_freq_dex * (sample_rate / SAMPLE_COUNT);
 }
 
+// abs(a) must be <= 1
+constexpr __always_inline fix15 multiply_fix15_unit(fix15 a, fix15 b) {
+    int32_t bh = b >> 15;
+    int32_t bl = b & 0x7fff;
+    return ((a * bl) >> 15) + (a * bh);;
+}
+
 void FIX_FFT::FFT() {
     // Bit Reversal Permutation
     // Bit reversal code below originally based on that found here: 
@@ -114,8 +125,8 @@ void FIX_FFT::FFT() {
                 // j gets the index of the FFT element being combined with i
                 int j = i + L;
                 // compute the trig terms (bottom half of the above matrix)
-                fix15 tr = multiply_fix15(wr, fr[j]) - multiply_fix15(wi, fi[j]);
-                fix15 ti = multiply_fix15(wr, fi[j]) + multiply_fix15(wi, fr[j]);
+                fix15 tr = multiply_fix15_unit(wr, fr[j]) - multiply_fix15_unit(wi, fi[j]);
+                fix15 ti = multiply_fix15_unit(wr, fi[j]) + multiply_fix15_unit(wi, fr[j]);
                 // divide ith index elements by two (top half of above matrix)
                 fix15 qr = fr[i] >> 1;
                 fix15 qi = fi[i] >> 1;

--- a/fixed_fft.hpp
+++ b/fixed_fft.hpp
@@ -36,14 +36,14 @@ class FIX_FFT {
         void FFT();
         void init();
     public:
-        uint16_t sample_array[SAMPLE_COUNT];
+        int16_t sample_array[SAMPLE_COUNT];
 
         FIX_FFT() : FIX_FFT(44100.0f) {};
         FIX_FFT(float sample_rate) : sample_rate(sample_rate) {
                 log2_samples = log2(SAMPLE_COUNT);
                 shift_amount = 16u - log2_samples;
 
-                memset(sample_array, 0, SAMPLE_COUNT);
+                memset(sample_array, 0, SAMPLE_COUNT * sizeof(int16_t));
 
                 memset(fr, 0, SAMPLE_COUNT * sizeof(fix15));
                 memset(fi, 0, SAMPLE_COUNT * sizeof(fix15));
@@ -55,4 +55,5 @@ class FIX_FFT {
         void update();
         float max_frequency();
         int get_scaled(unsigned int i, unsigned int scale);
+        int get_scaled_fix15(unsigned int i, fix15 scale);
 };


### PR DESCRIPTION
The FFT inputs were being converted to unsigned, which messed with the frequency distribution quite a lot!

Fixed that and then needed to scale the output a bit to get back to a reasonable range.

Also an optimization for multiply which makes the FFT fast enough to do two samples together to give a smoother output.  The optimization is present here but not the multiple samples - see my dev branch for that.