### PR TITLE
Support for "headless", eg. Pico Audio

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,6 +22,9 @@ jobs:
           - name: Galactic Unicorn
             board: galactic
             cmake-args: '-DDISPLAY_PATH=display/galactic/galactic_unicorn.cmake'
+          - name: Headless Unicorn
+            board: none
+            cmake-args: '-DHEADLESS=1'
 
     runs-on: ubuntu-20.04
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ set(CMAKE_CXX_STANDARD 17)
 pico_sdk_init()
 
 include(bluetooth/bluetooth.cmake)
+
+if(HEADLESS)
+set(DISPLAY_NAME "Headless Unicorn")
+else()
 include(effect/rainbow_fft.cmake)
 include(effect/classic_fft.cmake)
 
@@ -21,6 +25,8 @@ else()
 message(WARNING "Using default display (display/galactic/galactic_unicorn.cmake)...")
 include(display/galactic/galactic_unicorn.cmake)
 endif()
+endif()
+
 
 add_executable(${NAME}
     ${CMAKE_CURRENT_LIST_DIR}/src/main.cpp
@@ -37,9 +43,6 @@ target_link_libraries(${NAME}
     picow_bt_example_common
     pico_audio_i2s
     pico_multicore
-    display
-    rainbow_fft
-    classic_fft
 )
 
 message(WARNING "Display: ${DISPLAY_NAME}")
@@ -49,6 +52,18 @@ target_compile_definitions(${NAME} PRIVATE
     PICO_AUDIO_I2S_CLOCK_PIN_BASE=10
     BLUETOOTH_DEVICE_NAME="${DISPLAY_NAME}"
 )
+
+if(HEADLESS)
+target_compile_definitions(${NAME} PRIVATE
+    HEADLESS=1
+)
+else()
+target_link_libraries(${NAME}
+    display
+    rainbow_fft
+    classic_fft
+)
+endif()
 
 pico_enable_stdio_usb(${NAME} 1)
 pico_add_extra_outputs(${NAME})

--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ mkdir build.cosmic
 cd build.cosmic
 cmake .. -DPICO_SDK_PATH=../../pico-sdk -DPICO_EXTRAS_PATH=../../pico-extras -DPICO_BOARD=pico_w -DDISPLAY_PATH=display/cosmic/cosmic_unicorn.cmake -DCMAKE_BUILD_TYPE=Release
 ```
+
+For Pico Audio, ie. without a display:
+
+```bash
+mkdir build.headless
+cd build.headless
+cmake .. -DPICO_SDK_PATH=../../pico-sdk -DPICO_EXTRAS_PATH=../../pico-extras -DPICO_BOARD=none -DHEADLESS=1 -DCMAKE_BUILD_TYPE=Release
+```

--- a/src/a2dp_sink.cpp
+++ b/src/a2dp_sink.cpp
@@ -945,7 +945,7 @@ static void stdin_process(char cmd){
 
     switch (cmd){
         case 'b':
-            status = a2dp_sink_establish_stream(device_addr, stream_endpoint->a2dp_local_seid, &a2dp_connection->a2dp_cid);
+            status = a2dp_sink_establish_stream(device_addr, /*stream_endpoint->a2dp_local_seid, */&a2dp_connection->a2dp_cid);
             printf(" - Create AVDTP connection to addr %s, and local seid %d, cid 0x%02x.\n",
                    bd_addr_to_str(device_addr), a2dp_connection->a2dp_local_seid, a2dp_connection->a2dp_cid);
             break;


### PR DESCRIPTION
Although `pico-examples` `a2dp_sink_demo` works quite well unaltered, for completeness it'd be good to have a precompiled BT speaker firmware for the Pico Audio board, rather than having to do the whole SDK setup just to compile one image. I know this is all about the blinkenlights, but in lieu of a Pico Audio-specific downloadable to do the same thing, it seems straightforward.

I've done this brutally by adding a `HEADLESS` constant and `#ifndef`'ing the display-specific code.  It could be done much cleaner, but I'd expect that'd require substantial refactoring to support an efficient "null" Display class.

I suspect there's some work being done capturing the audio buffer that might be unnecessary if it's not passed out to the Display/Effect code. Is `btstack_audio_pico.cpp` redundant without a display? If so, how to remove it?